### PR TITLE
fix: avoid recursion when a provider also uses processors

### DIFF
--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -753,28 +753,32 @@ class Store:
 
                 _sig = cast("Signature", sig)  # mypy thinks sig is still optional
 
-                # first, get and call the provider functions for each parameter type:
-                _kwargs: dict[str, Any] = {}
-                for param in _sig.parameters.values():
-                    provided = self.provide(param.annotation)
-                    if provided is not None:
-                        _kwargs[param.name] = provided
-
                 # use bind_partial to allow the caller to still provide their own args
                 # if desired. (i.e. the injected deps are only used if not provided)
                 bound = _sig.bind_partial(*args, **kwargs)
                 bound.apply_defaults()
 
+                # first, get and call the provider functions for each parameter type:
+                _injected_names: set[str] = set()
+                for param in _sig.parameters.values():
+                    if param.name not in bound.arguments:
+                        provided = self.provide(param.annotation)
+                        if provided is not None:
+                            _injected_names.add(param.name)
+                            bound.arguments[param.name] = provided
+
                 # call the function with injected values
                 try:
-                    result = func(**{**_kwargs, **bound.arguments})
+                    result = func(**bound.arguments)
                 except TypeError as e:
                     if "missing" not in e.args[0]:
                         raise  # pragma: no cover
                     # likely a required argument is still missing.
                     # show what was injected and raise
                     _argnames = (
-                        f"arguments: {set(_kwargs)!r}" if _kwargs else "NO arguments"
+                        f"arguments: {_injected_names!r}"
+                        if _injected_names
+                        else "NO arguments"
                     )
                     raise TypeError(
                         f"After injecting dependencies for {_argnames}, {e}"


### PR DESCRIPTION
This fixes the recursion error mentioned in https://github.com/pyapp-kit/in-n-out/issues/50#issuecomment-1445465574 ... (when a provider function also uses `inject_processors`)