### PR TITLE
feat: allow registration of a processor function that doesn't process its first argument

### DIFF
--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -572,7 +572,8 @@ class Store:
                 if raise_exception:
                     raise e
                 warnings.warn(
-                    f"Processor {processor!r} failed to process result {result!r}: {e}"
+                    f"Processor {processor!r} failed to process result {result!r}: {e}",
+                    stacklevel=2,
                 )
             if first_processor_only:
                 break
@@ -1030,7 +1031,7 @@ class Store:
                             if i != 0:
                                 param_to_process = name
                             break
-                    else:
+                    else:  # pragma: no cover
                         warnings.warn(
                             f"Processor has no parameter annotated as: {type_!r}",
                             stacklevel=2,

--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -1061,7 +1061,7 @@ class Store:
                 type_ = _type_from_hints(hints)
                 if type_ is None:
                     raise ValueError(err_msg.format(callback))
-            elif not providers:
+            elif not is_provider:
                 annotations = getattr(callback, "__annotations__", {})
                 if annotations:
                     for i, (name, hint) in enumerate(annotations.items()):

--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -4,7 +4,7 @@ import contextlib
 import types
 import warnings
 import weakref
-from functools import cached_property, partial, wraps
+from functools import cached_property, wraps
 from inspect import CO_VARARGS, isgeneratorfunction, unwrap
 from types import CodeType
 from typing import (
@@ -1044,7 +1044,6 @@ class Store:
                 callback = self._methodwrap(callback, reg, cache_map)
 
             if param_to_process is not None:
-                callback = partial(callback, **{param_to_process: None})
 
                 @wraps(callback)
                 def _call_as_kwarg(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,6 @@ def test_store() -> Iterator[Store]:
 
 
 @pytest.fixture(autouse=True)
-def clear_global_store():
+def clear_global_store() -> Iterator[None]:
     yield
     Store.get_store().clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,6 @@ def test_store() -> Iterator[Store]:
 
 
 @pytest.fixture(autouse=True)
-def clear_global_store() -> Iterator[None]:
+def clear_global_store():
     yield
     Store.get_store().clear()

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -134,3 +134,68 @@ def test_global_register():
     ino.register_processor(f)
     ino.process(1)
     mock.assert_called_once_with(1)
+
+
+# def test_processors_with_injections() -> None:
+#     """Test that we can use processors with injections."""
+
+#     class ThingToProcess:
+#         ...
+
+#     class InjectedDep:
+#         ...
+
+#     dep = InjectedDep()
+#     t2p = ThingToProcess()
+#     mock = Mock()
+
+#     @ino.inject
+#     def processor_that_has_injections(p0: InjectedDep, p1: ThingToProcess) -> None:
+#         mock(p0, p1)
+
+#     ino.register_processor(processor_that_has_injections, type_hint=ThingToProcess)
+
+#     @ino.inject_processors
+#     def return_a_thing() -> ThingToProcess:
+#         return t2p
+
+#     with pytest.warns(UserWarning, match="Processor .* failed to process result"):
+#         return_a_thing()
+
+#     @ino.register_provider
+#     def provide_other_thing() -> InjectedDep:
+#         return dep
+
+#     return_a_thing()
+#     mock.assert_called_once_with(dep, t2p)
+
+
+# def test_multi_registered_processors_with_injections() -> None:
+#     class Thing:
+#         def __init__(self) -> None:
+#             self.list = []
+
+#     @ino.register_provider
+#     def dummy_provider() -> int:
+#         return 1
+
+#     @ino.inject
+#     @ino.inject_processors
+#     def thing_provider(x: int) -> Thing:
+#         return Thing()
+
+#     ino.register_provider(thing_provider)
+
+#     @ino.inject
+#     def add_item(x: int, thing: Thing) -> None:
+#         thing.list.append("item")
+
+#     ino.register_processor(add_item, type_hint=Thing)
+#     # ino.register_processor(add_item, type_hint=Thing)
+#     # ino.register_processor(add_item, type_hint=Thing)
+
+#     @ino.inject
+#     def func(thing: Thing) -> list:
+#         return thing.list
+
+#     assert func() == ["item"] * 1

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, Union
+from typing import List, Optional, Sequence, Union
 from unittest.mock import Mock
 
 import pytest
@@ -136,66 +136,80 @@ def test_global_register():
     mock.assert_called_once_with(1)
 
 
-# def test_processors_with_injections() -> None:
-#     """Test that we can use processors with injections."""
+def test_processors_with_injections() -> None:
+    """Test that we can use processors with injections."""
 
-#     class ThingToProcess:
-#         ...
+    class ThingToProcess:
+        ...
 
-#     class InjectedDep:
-#         ...
+    class InjectedDep:
+        ...
 
-#     dep = InjectedDep()
-#     t2p = ThingToProcess()
-#     mock = Mock()
+    dep = InjectedDep()
+    t2p = ThingToProcess()
+    mock = Mock()
 
-#     @ino.inject
-#     def processor_that_has_injections(p0: InjectedDep, p1: ThingToProcess) -> None:
-#         mock(p0, p1)
+    @ino.inject
+    def processor_that_has_injections(p0: InjectedDep, p1: ThingToProcess) -> None:
+        mock(p0, p1)
 
-#     ino.register_processor(processor_that_has_injections, type_hint=ThingToProcess)
+    ino.register_processor(processor_that_has_injections, type_hint=ThingToProcess)
 
-#     @ino.inject_processors
-#     def return_a_thing() -> ThingToProcess:
-#         return t2p
+    @ino.inject_processors
+    def return_a_thing() -> ThingToProcess:
+        return t2p
 
-#     with pytest.warns(UserWarning, match="Processor .* failed to process result"):
-#         return_a_thing()
+    with pytest.warns(UserWarning, match="Processor .* failed to process result"):
+        return_a_thing()
 
-#     @ino.register_provider
-#     def provide_other_thing() -> InjectedDep:
-#         return dep
+    @ino.register_provider
+    def provide_other_thing() -> InjectedDep:
+        return dep
 
-#     return_a_thing()
-#     mock.assert_called_once_with(dep, t2p)
+    return_a_thing()
+    mock.assert_called_once_with(dep, t2p)
 
 
-# def test_multi_registered_processors_with_injections() -> None:
-#     class Thing:
-#         def __init__(self) -> None:
-#             self.list = []
 
-#     @ino.register_provider
-#     def dummy_provider() -> int:
-#         return 1
+def test_processors_with_injections222() -> None:
 
-#     @ino.inject
-#     @ino.inject_processors
-#     def thing_provider(x: int) -> Thing:
-#         return Thing()
+    class Dummy:
+        pass
 
-#     ino.register_provider(thing_provider)
+    class Thing:
+        def __init__(self):
+            self.list = []
 
-#     @ino.inject
-#     def add_item(x: int, thing: Thing) -> None:
-#         thing.list.append("item")
+    def dummy_provider() -> Dummy:
+        return Dummy()
 
-#     ino.register_processor(add_item, type_hint=Thing)
-#     # ino.register_processor(add_item, type_hint=Thing)
-#     # ino.register_processor(add_item, type_hint=Thing)
+    @ino.inject
+    @ino.inject_processors
+    def thing_provider(dummy: Dummy) -> Thing:
+        return Thing()
 
-#     @ino.inject
-#     def func(thing: Thing) -> list:
-#         return thing.list
+    ino.register_provider(dummy_provider)
+    ino.register_provider(thing_provider)
 
-#     assert func() == ["item"] * 1
+    # def add_item(thing: Thing):
+    #     thing.list.append("item")
+
+    @ino.inject
+    def add_item(thing: Thing, dummy: Dummy):
+        thing.list.append("item")
+
+    # def add_item(thing: Thing):
+    #     @ino.inject
+    #     def inner(dummy: Dummy):
+    #         thing.list.append("item")
+    #     inner()
+
+    ino.register_processor(add_item)
+    ino.register_processor(add_item)
+    ino.register_processor(add_item)
+
+    @ino.inject
+    def func(thing: Thing):
+        return thing.list
+
+    assert func() == ["item"] * 3


### PR DESCRIPTION
makes this valid:

```python
    @ino.inject
    def takes_two_things(p0: int, p1: ThingToProcess) -> None:
        mock(p0, p1)

    ino.register_processor(takes_two_things, type_hint=ThingToProcess)
```

closes #50

@davidbrochart, I would be curious to hear if, after reading the comments on #50, whether you think this is actually an important feature to add, or whether it would have been sufficient in your case to just swap the order of the parameters on your `add_item` function.

```python
# put the thing it processes first:
@ino.inject
def add_item(thing: Thing, dummy: Dummy):
    thing.list.append("item")
ino.register_processor(add_item)

#rather than second:
@ino.inject
def add_item(dummy: Dummy, thing: Thing):
    thing.list.append("item")
ino.register_processor(add_item, type_hint= Thing)
```


(otherwise, it feels like additional complexity)