### PR TITLE
chore: Add error message when injector cannot determine parameter

### DIFF
--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -794,12 +794,6 @@ class Store:
                             )
                             _injected_names.add(param.name)
                             bound.arguments[param.name] = provided
-                        elif param.default is param.empty:
-                            raise RuntimeError(
-                                f"Could not provide {param.name} for {func} "
-                                f"when using "
-                                f"{list(self.iter_providers(param.annotation))}"
-                            )
 
                 # call the function with injected values
                 logger.debug(
@@ -821,6 +815,13 @@ class Store:
                         else "NO arguments"
                     )
                     logger.exception(e)
+                    for param in sig_.parameters.values():
+                        if param.name not in bound.arguments and param.default is param.empty:
+                            logger.error(
+                                f"Do not have argument for {param.name}: using providers "
+                                f"{list(self.iter_providers(param.annotation))}"
+                            )
+
                     raise TypeError(
                         f"After injecting dependencies for {_argnames}, {e}"
                     ) from e

--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -797,7 +797,8 @@ class Store:
                         elif param.default is param.empty:
                             raise RuntimeError(
                                 f"Could not provide {param.name} for {func} "
-                                f"when using {list(self.iter_providers(param.annotation))}"
+                                f"when using "
+                                f"{list(self.iter_providers(param.annotation))}"
                             )
 
                 # call the function with injected values

--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -785,11 +785,6 @@ class Store:
                 for param in sig_.parameters.values():
                     if param.name not in bound.arguments:
                         provided = self.provide(param.annotation)
-                        if provided is None and param.default is param.empty:
-                            raise RuntimeError(
-                                f"Could not provide {param.name} for {func} "
-                                f"when using {list(self.iter_providers(param.annotation))}"
-                            )
                         if provided is not None:
                             logger.debug(
                                 "  injecting %s: %s = %r",
@@ -799,6 +794,11 @@ class Store:
                             )
                             _injected_names.add(param.name)
                             bound.arguments[param.name] = provided
+                        elif param.default is param.empty:
+                            raise RuntimeError(
+                                f"Could not provide {param.name} for {func} "
+                                f"when using {list(self.iter_providers(param.annotation))}"
+                            )
 
                 # call the function with injected values
                 logger.debug(

--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -821,7 +821,8 @@ class Store:
                             and param.default is param.empty
                         ):
                             logger.error(
-                                f"Do not have argument for {param.name}: using providers "
+                                f"Do not have argument for {param.name}: using "
+                                "providers "
                                 f"{list(self.iter_providers(param.annotation))}"
                             )
 

--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -816,7 +816,10 @@ class Store:
                     )
                     logger.exception(e)
                     for param in sig_.parameters.values():
-                        if param.name not in bound.arguments and param.default is param.empty:
+                        if (
+                            param.name not in bound.arguments
+                            and param.default is param.empty
+                        ):
                             logger.error(
                                 f"Do not have argument for {param.name}: using providers "
                                 f"{list(self.iter_providers(param.annotation))}"

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -63,9 +63,8 @@ def test_injection_missing():
     def f(x: int):
         return x
 
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(RuntimeError, match="Could not provide x for <function"):
         f()
-    assert "missing 1 required positional argument" in str(e.value)
     assert f(4) == 4
     with register(providers={int: lambda: 1}):
         assert f() == 1
@@ -194,7 +193,7 @@ def test_optional_provider_with_required_arg(test_store: Store):
         mock(x)
 
     with test_store.register(providers={Optional[int]: lambda: None}):
-        with pytest.raises(TypeError, match="missing 1 required positional argument"):
+        with pytest.raises(RuntimeError, match="Could not provide x for <function"):
             f()
         mock.assert_not_called()
 

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -63,7 +63,7 @@ def test_injection_missing():
     def f(x: int):
         return x
 
-    with pytest.raises(RuntimeError, match="Could not provide x for <function"):
+    with pytest.raises(TypeError, match="After injecting dependencies"):
         f()
     assert f(4) == 4
     with register(providers={int: lambda: 1}):

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -193,7 +193,7 @@ def test_optional_provider_with_required_arg(test_store: Store):
         mock(x)
 
     with test_store.register(providers={Optional[int]: lambda: None}):
-        with pytest.raises(RuntimeError, match="Could not provide x for <function"):
+        with pytest.raises(TypeError, match="missing 1 required positional argument"):
             f()
         mock.assert_not_called()
 


### PR DESCRIPTION
Add better error message when in-n-out fails to determine value for injection when no default value is provided.

I suggested this in https://github.com/napari/napari/issues/5803