### PR TITLE
fix: injecting None into takes optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [v0.1.9](https://github.com/pyapp-kit/in-n-out/tree/v0.1.9) (2023-10-10)
+
+[Full Changelog](https://github.com/pyapp-kit/in-n-out/compare/v0.1.8...v0.1.9)
+
+**Implemented enhancements:**
+
+- feat: support py312 [\#73](https://github.com/pyapp-kit/in-n-out/pull/73) ([tlambert03](https://github.com/tlambert03))
+
+**Fixed bugs:**
+
+- fix: pass globals through signature resolution [\#75](https://github.com/pyapp-kit/in-n-out/pull/75) ([tlambert03](https://github.com/tlambert03))
+
+**Documentation:**
+
+- docs: Fix typos in \_store.py [\#69](https://github.com/pyapp-kit/in-n-out/pull/69) ([lucyleeow](https://github.com/lucyleeow))
+
+**Merged pull requests:**
+
+- ci\(dependabot\): bump actions/checkout from 3 to 4 [\#70](https://github.com/pyapp-kit/in-n-out/pull/70) ([dependabot[bot]](https://github.com/apps/dependabot))
+
 ## [v0.1.8](https://github.com/pyapp-kit/in-n-out/tree/v0.1.8) (2023-07-06)
 
 [Full Changelog](https://github.com/pyapp-kit/in-n-out/compare/v0.1.7...v0.1.8)

--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -27,7 +27,7 @@ from typing import (
 )
 
 from ._type_resolution import _resolve_sig_or_inform, resolve_type_hints
-from ._util import _split_union, issubclassable
+from ._util import _split_union, is_optional, issubclassable
 
 logger = getLogger("in_n_out")
 
@@ -783,7 +783,7 @@ class Store:
                 for param in sig.parameters.values():
                     if param.name not in bound.arguments:
                         provided = self.provide(param.annotation)
-                        if provided is not None:
+                        if is_optional(param.annotation) or provided is not None:
                             logger.debug(
                                 "  injecting %s: %s = %r",
                                 param.name,

--- a/src/in_n_out/_util.py
+++ b/src/in_n_out/_util.py
@@ -11,7 +11,13 @@ if hasattr(types, "UnionType"):
 
 
 def _is_union(type_: Any) -> bool:
+    """Return True if `type_` is a Union type."""
     return get_origin(type_) in UNION_TYPES
+
+
+def is_optional(type_: Any) -> bool:
+    """Return True if `type_` is Optional[T]."""
+    return _split_union(type_)[1]
 
 
 def _split_union(type_: Any) -> Tuple[List[Type], bool]:

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -101,8 +101,7 @@ def test_injection_with_generator():
 def test_injection_without_args():
     """it just returns the same function"""
 
-    def f():
-        ...
+    def f(): ...
 
     assert inject(f) is f
 
@@ -271,3 +270,18 @@ def test_partial_annotations(test_store: Store):
     with test_store.register(providers={Foo: lambda: foo}):
         assert injected(bar=2) == (foo, 2)  # type: ignore
         assert injected2(2) == (foo, 2)  # type: ignore
+
+
+def test_inject_into_required_optional() -> None:
+    class Thing: ...
+
+    def f(i: int | None) -> int | None:
+        return i
+
+    with register(providers={Optional[Thing]: lambda: None}):
+        assert inject(f)() is None
+
+    thing = Thing()
+    with register(providers={Optional[Thing]: lambda: thing}):
+        assert inject(f)() is thing
+

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -139,7 +139,7 @@ def test_injection_errors(in_func, on_unresolved, on_unannotated):
         if on_unresolved == "raise":
             ctx = pytest.raises(NameError, match=UNRESOLVED_MSG)
         elif on_unresolved == "warn":
-            ctx = pytest.warns(UserWarning, match=UNRESOLVED_MSG)
+            ctx = pytest.warns(UserWarning)  # will warn both
             if "unannotated" in in_func.__name__:
                 if on_unannotated == "raise":
                     ctxb = pytest.raises(TypeError, match=UNANNOTATED_MSG)

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -275,8 +275,13 @@ def test_partial_annotations(test_store: Store):
 def test_inject_into_required_optional() -> None:
     class Thing: ...
 
-    def f(i: int | None) -> int | None:
+    def f(i: Thing | None) -> Thing | None:
         return i
+
+    with pytest.raises(TypeError, match="missing 1 required positional argument"):
+        f()  # type: ignore
+
+    assert inject(f)() is None  # no provider needed
 
     with register(providers={Optional[Thing]: lambda: None}):
         assert inject(f)() is None
@@ -284,4 +289,3 @@ def test_inject_into_required_optional() -> None:
     thing = Thing()
     with register(providers={Optional[Thing]: lambda: thing}):
         assert inject(f)() is thing
-

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -277,7 +277,7 @@ def test_inject_into_required_optional() -> None:
     class Thing:
         ...
 
-    def f(i: Thing | None) -> Thing | None:
+    def f(i: Optional[Thing]) -> Optional[Thing]:
         return i
 
     with pytest.raises(TypeError, match="missing 1 required positional argument"):


### PR DESCRIPTION
fixes a bug where injecting into a function that takes an `Thing | None` but doesn't include a default of None raise an exception if the provider returns None

```python
import in_n_out as ino

store = ino.Store(name="store")


class Thing: ...


@store.register_provider
def get_thing() -> Thing | None:
    return None


@store.inject
def use_thing(thing: Thing | None) -> None:
    print(f"got {thing=}")


use_thing()

```