### PR TITLE
feat: Try to inject parameter value if default value is None

### DIFF
--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -778,7 +778,7 @@ class Store:
                 # first, get and call the provider functions for each parameter type:
                 _injected_names: set[str] = set()
                 for param in sig.parameters.values():
-                    if param.name not in bound.arguments:
+                    if param.name not in bound.arguments or bound.arguments[param.name] is None:
                         provided = self.provide(param.annotation)
                         if provided is not None or is_optional(param.annotation):
                             logger.debug(

--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -778,7 +778,10 @@ class Store:
                 # first, get and call the provider functions for each parameter type:
                 _injected_names: set[str] = set()
                 for param in sig.parameters.values():
-                    if param.name not in bound.arguments or bound.arguments[param.name] is None:
+                    if (
+                        param.name not in bound.arguments
+                        or bound.arguments[param.name] is None
+                    ):
                         provided = self.provide(param.annotation)
                         if provided is not None or is_optional(param.annotation):
                             logger.debug(

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -296,3 +296,18 @@ def test_inject_into_required_optional() -> None:
     thing = Thing()
     with register(providers={Optional[Thing]: lambda: thing}):
         assert inject(f)() is thing
+
+
+def test_inject_into_optional_with_default() -> None:
+    class Thing: ...
+
+    def f(i: Optional[Thing] = None) -> Optional[Thing]:
+        return i
+
+    thing = Thing()
+    with register(providers={Optional[Thing]: lambda: thing}):
+        assert inject(f)() is thing
+    with register(providers={Thing: lambda: thing}):
+        assert inject(f)() is thing
+
+    assert inject(f)() is None


### PR DESCRIPTION
Currently, in-n-out do not allow injecting parameters for function with default value. This does not allow creating an action that has optional injection but will not crash on injection failure. 

A workaround for this may be modifying the signature of the implementation to remove the default value information from the signature. But it is really hacky. 

Alternative to this, PR may define a special generic type to inform that injection should be performed even if a default value is provided. 