### PR TITLE
chore: new error message

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -132,8 +132,8 @@ def give_me_a_string(s: str) -> str:
     return s
 
 give_me_a_string()
-# TypeError: After injecting dependencies for NO arguments,
-#   give_me_a_string() missing 1 required positional argument: 's'
+# TypeError: Error calling in-n-out injected function '__main__.give_me_a_string' with kwargs {}.
+# See TypeError above for more details.
 ```
 
 !!!note "function defaults"

--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -804,11 +804,6 @@ class Store:
                         raise  # pragma: no cover
                     # likely a required argument is still missing.
                     # show what was injected and raise
-                    _argnames = (
-                        f"arguments: {_injected_names!r}"
-                        if _injected_names
-                        else "NO arguments"
-                    )
                     logger.exception(e)
                     for param in sig.parameters.values():
                         if (
@@ -821,8 +816,13 @@ class Store:
                                 f"{list(self.iter_providers(param.annotation))}"
                             )
 
+                    mod_name = getattr(func, "__module__", "")
+                    func_name = getattr(func, "__qualname__", str(func))
+                    full_name = f"{mod_name}.{func_name}"
                     raise TypeError(
-                        f"After injecting dependencies for {_argnames}, {e}"
+                        f"Error calling in-n-out injected function {full_name!r} with "
+                        f"kwargs {bound.arguments!r}.\n\n"
+                        f"See {type(e).__name__} above for more details."
                     ) from e
 
                 return result

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -192,7 +192,7 @@ def test_optional_provider_with_required_arg(test_store: Store) -> None:
         mock(x)
 
     with test_store.register(providers={Optional[int]: lambda: None}):
-        with pytest.raises(TypeError, match="missing 1 required positional argument"):
+        with pytest.raises(TypeError, match="Error calling in-n-out injected function"):
             f()
         mock.assert_not_called()
 

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -69,7 +69,7 @@ def test_injection_missing():
     def f(x: int) -> int:
         return x
 
-    with pytest.raises(TypeError, match="After injecting dependencies"):
+    with pytest.raises(TypeError, match="Error calling in-n-out injected function"):
         f()
     assert f(4) == 4
     with register(providers={int: lambda: 1}):


### PR DESCRIPTION
closes #120 

@lucyleeow, running your example now would show this:


```python
from in_n_out import Store
from functools import partial

store = Store.create('my-store')

@store.inject
def myfun(a: str):
    def inner_fun(thing: 'thing'):
        return thing
    return inner_fun()

store.inject(partial(myfun, a='a'))()
```

```pytb
Traceback (most recent call last):
  File "/Users/talley/dev/self/in-n-out/src/in_n_out/_store.py", line 801, in _exec
    result = func(**bound.arguments)  # type: ignore[call-arg]
  File "/Users/talley/dev/self/in-n-out/x.py", line 10, in myfun
    return inner_fun()
TypeError: inner_fun() missing 1 required positional argument: 'thing'
Traceback (most recent call last):
  File "/Users/talley/dev/self/in-n-out/src/in_n_out/_store.py", line 801, in _exec
    result = func(**bound.arguments)  # type: ignore[call-arg]
  File "/Users/talley/dev/self/in-n-out/x.py", line 10, in myfun
    return inner_fun()
TypeError: inner_fun() missing 1 required positional argument: 'thing'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/talley/dev/self/in-n-out/x.py", line 12, in <module>
    store.inject(partial(myfun, a='a'))()
  File "/Users/talley/dev/self/in-n-out/src/in_n_out/_store.py", line 801, in _exec
    result = func(**bound.arguments)  # type: ignore[call-arg]
  File "/Users/talley/dev/self/in-n-out/src/in_n_out/_store.py", line 822, in _exec
    raise TypeError(
TypeError: Error calling in-n-out injected function '__main__.myfun' with kwargs {'a': 'a'}.

See TypeError above for more details.
```

more than happy to change it, or if you guys have a more specific idea about what you'd like the error to look like, happy to take PRs and close this one.

note: part of the weird duplication in this error message is caused by calling store.inject on a partial that wraps an already-injected function :) ... so reconsider that pattern too if you can