### PR TITLE
chore: drop python 3.9, support 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,18 +42,13 @@ jobs:
             os: macos-latest
 
   test-app-model:
-    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@v2
+    # `dependency-group` is not in any tag yet; move back to a tag once one is cut.
+    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@65abcc0b091a0d45dbe3c589266160cc9b62f8dc
     with:
       dependency-repo: pyapp-kit/app-model
       dependency-extras: "qt"
+      dependency-group: "test-qt"
       qt: "PyQt6"
-      # app-model declares its test requirements as PEP 735 dependency groups,
-      # which pip cannot install as extras. Resolving that group pulls
-      # `app-model[qt]` and can replace the checked-out in-n-out with a release
-      # from PyPI, so reinstall it afterwards to keep this job testing the PR.
-      post-install-cmd: >-
-        python -m pip install --group ./pyapp-kit/app-model/pyproject.toml:test-qt &&
-        python -m pip install --no-deps --force-reinstall ./pyapp-kit/in-n-out
 
   benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,15 @@ jobs:
     uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@v2
     with:
       dependency-repo: pyapp-kit/app-model
-      dependency-extras: "qt,test,test-qt"
-      qt: "PyQt5"
+      dependency-extras: "qt"
+      qt: "PyQt6"
+      # app-model declares its test requirements as PEP 735 dependency groups,
+      # which pip cannot install as extras. Resolving that group pulls
+      # `app-model[qt]` and can replace the checked-out in-n-out with a release
+      # from PyPI, so reinstall it afterwards to keep this job testing the PR.
+      post-install-cmd: >-
+        python -m pip install --group ./pyapp-kit/app-model/pyproject.toml:test-qt &&
+        python -m pip install --no-deps --force-reinstall ./pyapp-kit/in-n-out
 
   benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,15 +32,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
-          - python-version: "3.9"
-            os: ubuntu-latest
-          - python-version: "3.9"
-            os: macos-13
-          - python-version: "3.11"
+          - python-version: "3.10"
             os: macos-latest
           - python-version: "3.12"
+            os: macos-latest
+          - python-version: "3.14"
             os: macos-latest
 
   test-app-model:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,24 +5,24 @@ ci:
 
 repos:
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.23
+    rev: '0.26'
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/crate-ci/typos
-    rev: dictgen-v0.3.1
+    rev: v1.50.0
     hooks:
       - id: typos
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.16.5
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --unsafe-fixes]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v2.3.1
     hooks:
       - id: mypy
         files: "^src/"

--- a/README.md
+++ b/README.md
@@ -50,17 +50,18 @@ This also supports processing *return* values as well
 (injection of intentional side effects):
 
 ```python
-
 @ino.inject_processors
 def func2(thing: Thing) -> str:
     return thing.name
 
+
 def greet_name(name: str):
     print(f"Hello, {name}!")
 
+
 ino.register_processor(greet_name)
 
-func2(Thing('Bob'))  # prints "Hello, Bob!"
+func2(Thing("Bob"))  # prints "Hello, Bob!"
 ```
 
 ### Alternatives

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -19,14 +19,14 @@ processors. More than one provider/processor can be registered per type.
 ```python
 from in_n_out import Store
 
-store = Store.create('my-store')
+store = Store.create("my-store")
 ```
 
 This store can be retrieved later using `Store.get_store`, and
 destroyed using `Store.destroy`.
 
 ```python
-store = Store.get_store('my-store')
+store = Store.get_store("my-store")
 
 # Store.destroy('my-store') # would destroy the store... but we still want it :)
 ```
@@ -44,6 +44,7 @@ important to our application:
 ```python
 class Thing:
     """Some thing I care about."""
+
     def __init__(self, name: str):
         self.name = name
 ```
@@ -55,8 +56,10 @@ of the function to determine what type it provides.
 ```python
 import in_n_out as ino
 
+
 def heres_the_thing() -> Thing:
     return Thing("Thing")
+
 
 # register a provider of Thing
 store.register_provider(heres_the_thing)
@@ -120,6 +123,7 @@ print(get_things_name())  # prints "Thing"
     def get_things_name(thing: Thing) -> str:
         return thing.name
 
+
     print(get_things_name())  # prints "Thing"
     ```
 
@@ -130,6 +134,7 @@ an exception:
 @store.inject
 def give_me_a_string(s: str) -> str:
     return s
+
 
 give_me_a_string()
 # TypeError: Error calling in-n-out injected function '__main__.give_me_a_string' with kwargs {}.
@@ -155,6 +160,7 @@ When registering multiple providers for the same type, you can use the
 def give_me_another_thing() -> Thing:
     return Thing("Another Thing")
 
+
 store.register_provider(give_me_another_thing, weight=10)
 print(get_things_name())  # prints "Another Thing"
 ```
@@ -167,6 +173,7 @@ providers.
 ```python
 def most_important_thing() -> Thing:
     return Thing("Most Important Thing")
+
 
 with store.register_provider(most_important_thing, weight=20):
     print(get_things_name())  # prints "Most Important Thing"
@@ -197,12 +204,14 @@ using the [`Store.register_processor`][in_n_out.Store.register_processor] method
 def get_things_name(thing: Thing) -> str:
     return thing.name
 
+
 def greet_name(name: str):
     print(f"Hello, {name}!")
 
+
 store.register_processor(greet_name)
 
-get_things_name(Thing('Bob'))  # prints "Hello, Bob!"  (and still returns "Bob")
+get_things_name(Thing("Bob"))  # prints "Hello, Bob!"  (and still returns "Bob")
 ```
 
 !!!warning "Careful"
@@ -255,13 +264,15 @@ def highlight_document(document: Document):
 from in_n_out import Store
 
 # create a store
-store = Store.create('my-store')
+store = Store.create("my-store")
+
 
 # register a Document provider
 @store.register_provider
 def get_current_document() -> Document:
     # get the current document from somewhere
     ...
+
 
 # somehow gather functionality from plugins
 from some_plugin import highlight_document

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,15 +9,18 @@ and minimal impact on source code.
 ```python
 import in_n_out as ino
 
+
 # register functions that provide a dependency
 @ino.register_provider
 def some_number() -> int:
     return 42
 
+
 # inject dependencies into functions
 @ino.inject
 def print_square(num: int):
-    print(num ** 2)
+    print(num**2)
+
 
 print_square()  # prints 1764
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          import:
+          inventories:
             - https://docs.python.org/3/objects.inv
           options:
             docstring_style: numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,18 +8,18 @@ build-backend = "hatchling.build"
 name = "in-n-out"
 description = " plugable dependency injection and result processing"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "BSD 3-Clause License" }
 authors = [{ email = "talley.lambert@gmail.com", name = "Talley Lambert" }]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dynamic = ["version"]
@@ -67,7 +67,7 @@ documentations = "https://ino.rtfd.io"
 [tool.ruff]
 line-length = 88
 src = ["src", "tests"]
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 pydocstyle = { convention = "numpy" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,12 +50,13 @@ dev = [
     "rich",
 ]
 docs = [
-    "mkdocs-gen-files==0.5.0",
-    "mkdocs-literate-nav==0.6.1",
-    "mkdocs-material==9.5.34",
+    "mkdocs-gen-files==0.6.1",
+    "mkdocs-literate-nav==0.6.3",
+    "mkdocs-material==9.7.7",
     "mkdocs==1.6.1",
-    "mkdocstrings-python==1.11.1",
-    "griffe==1.3.0",
+    "mkdocstrings==1.0.6",
+    "mkdocstrings-python==2.0.7",
+    "griffe==2.2.0",
 ]
 
 [project.urls]

--- a/src/in_n_out/__init__.py
+++ b/src/in_n_out/__init__.py
@@ -51,7 +51,6 @@ __all__ = [
     "process",
     "provide",
     "register",
-    "register",
     "register_processor",
     "register_provider",
     "resolve_single_type_hints",

--- a/src/in_n_out/_global.py
+++ b/src/in_n_out/_global.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from textwrap import indent
-from typing import TYPE_CHECKING, Any, Callable, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from ._store import InjectionContext, Store
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
     from ._store import (
         P,
@@ -236,7 +236,7 @@ def inject(
     store: str | Store | None = None,
 ) -> Callable[..., R]:
     ...
-    # unfortunately, the best we can do is convert the signature to Callabe[..., R]
+    # unfortunately, the best we can do is convert the signature to Callable[..., R]
     # so we lose the parameter information.  but it seems better than having
     # "missing positional args" errors everywhere on injected functions.
 

--- a/src/in_n_out/_store.py
+++ b/src/in_n_out/_store.py
@@ -4,7 +4,7 @@ import contextlib
 import types
 import warnings
 import weakref
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import AbstractContextManager
 from functools import cached_property, wraps
 from inspect import CO_VARARGS, isgeneratorfunction, unwrap
@@ -13,11 +13,8 @@ from types import CodeType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     NamedTuple,
-    Optional,
     TypeVar,
-    Union,
     cast,
     overload,
 )
@@ -42,7 +39,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 Provider = Callable[[], Any]  # provider should be able to take no arguments
 Processor = Callable[[Any], Any]  # a processor must take one positional arg
-PPCallback = Union[Provider, Processor]
+PPCallback = Provider | Processor
 
 # typevars that retain the signatures of the values passed in
 ProviderVar = TypeVar("ProviderVar", bound=Provider)
@@ -56,22 +53,22 @@ Weight = float
 # (callback,)
 # (callback, type_hint)
 # (callback, type_hint, weight)
-ProviderTuple = Union[
-    tuple[Provider], tuple[Provider, THint], tuple[Provider, THint, Weight]
-]
-ProcessorTuple = Union[
-    tuple[Processor], tuple[Processor, THint], tuple[Processor, THint, Weight]
-]
-CallbackTuple = Union[ProviderTuple, ProcessorTuple]
+ProviderTuple = (
+    tuple[Provider] | tuple[Provider, THint] | tuple[Provider, THint, Weight]
+)
+ProcessorTuple = (
+    tuple[Processor] | tuple[Processor, THint] | tuple[Processor, THint, Weight]
+)
+CallbackTuple = ProviderTuple | ProcessorTuple
 
 # All of the valid argument that can be passed to register()
-ProviderIterable = Union[
-    Iterable[ProviderTuple],  # e.g. register(providers=[(lambda: 1, int)])
-    Mapping[THint, Provider],  # e.g. register(providers={int: lambda: 1})
-    Mapping[THint, object],  # e.g. register(providers={int: 1})
-]
-ProcessorIterable = Union[Iterable[ProcessorTuple], Mapping[THint, Processor]]
-CallbackIterable = Union[ProviderIterable, ProcessorIterable]
+ProviderIterable = (
+    Iterable[ProviderTuple]  # e.g. register(providers=[(lambda: 1, int)])
+    | Mapping[THint, Provider]  # e.g. register(providers={int: lambda: 1})
+    | Mapping[THint, object]  # e.g. register(providers={int: 1})
+)
+ProcessorIterable = Iterable[ProcessorTuple] | Mapping[THint, Processor]
+CallbackIterable = ProviderIterable | ProcessorIterable
 
 _GLOBAL = "global"
 
@@ -602,7 +599,7 @@ class Store:
         guess_self: bool | None = None,
     ) -> Callable[..., R]:
         ...
-        # unfortunately, the best we can do is convert the signature to Callabe[..., R]
+        # unfortunately, the best we can do is convert the signature to Callable[..., R]
         # so we lose the parameter information.  but it seems better than having
         # "missing positional args" errors everywhere on injected functions.
 
@@ -1053,7 +1050,7 @@ class Store:
                     type_ = rest[0]
                     weight = 0
                 elif len(rest) == 2:
-                    type_, weight = cast(tuple[Optional[THint], float], rest)
+                    type_, weight = cast("tuple[THint | None, float]", rest)
                 else:  # pragma: no cover
                     raise ValueError(f"Invalid callback tuple: {tup!r}")
 

--- a/src/in_n_out/_type_resolution.py
+++ b/src/in_n_out/_type_resolution.py
@@ -5,7 +5,7 @@ import typing
 import warnings
 from functools import lru_cache, partial
 from inspect import Signature
-from typing import TYPE_CHECKING, Any, Callable, ForwardRef
+from typing import TYPE_CHECKING, Any, ForwardRef
 
 try:
     from toolz import curry
@@ -15,6 +15,7 @@ except ImportError:  # pragma: no cover
     PARTIAL_TYPES = (partial,)
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Literal, _get_type_hints_obj_allowed_types
 
     RaiseWarnReturnIgnore = Literal["raise", "warn", "return", "ignore"]

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import sys
-from typing import Callable
+from typing import TYPE_CHECKING
 
 import pytest
 
 import in_n_out as ino
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 if all(x not in {"--codspeed", "--benchmark", "tests/test_bench.py"} for x in sys.argv):
     pytest.skip("use --benchmark to run benchmark", allow_module_level=True)

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -1,8 +1,8 @@
 import functools
-from collections.abc import Generator, Sequence
+from collections.abc import Callable, Generator, Sequence
 from contextlib import AbstractContextManager, nullcontext
 from inspect import isgeneratorfunction
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
@@ -166,7 +166,7 @@ def test_injection_errors(
 
 def test_processors_not_passed_none(test_store: Store) -> None:
     @test_store.inject_processors
-    def f(x: int) -> Optional[int]:
+    def f(x: int) -> int | None:
         return x if x > 5 else None
 
     mock = Mock()
@@ -191,12 +191,12 @@ def test_optional_provider_with_required_arg(test_store: Store) -> None:
     def f(x: int) -> None:
         mock(x)
 
-    with test_store.register(providers={Optional[int]: lambda: None}):
+    with test_store.register(providers={int | None: lambda: None}):
         with pytest.raises(TypeError, match="Error calling in-n-out injected function"):
             f()
         mock.assert_not_called()
 
-    with test_store.register(providers={Optional[int]: lambda: 2}):
+    with test_store.register(providers={int | None: lambda: 2}):
         f()
         mock.assert_called_once_with(2)
 
@@ -275,7 +275,7 @@ def test_partial_annotations(test_store: Store) -> None:
 def test_inject_into_required_optional() -> None:
     class Thing: ...
 
-    def f(i: Optional[Thing]) -> Optional[Thing]:
+    def f(i: Thing | None) -> Thing | None:
         return i
 
     with pytest.raises(TypeError, match="missing 1 required positional argument"):
@@ -283,22 +283,22 @@ def test_inject_into_required_optional() -> None:
 
     assert inject(f)() is None  # no provider needed
 
-    with register(providers={Optional[Thing]: lambda: None}):
+    with register(providers={Thing | None: lambda: None}):
         assert inject(f)() is None
 
     thing = Thing()
-    with register(providers={Optional[Thing]: lambda: thing}):
+    with register(providers={Thing | None: lambda: thing}):
         assert inject(f)() is thing
 
 
 def test_inject_into_optional_with_default() -> None:
     class Thing: ...
 
-    def f(i: Optional[Thing] = None) -> Optional[Thing]:
+    def f(i: Thing | None = None) -> Thing | None:
         return i
 
     thing = Thing()
-    with register(providers={Optional[Thing]: lambda: thing}):
+    with register(providers={Thing | None: lambda: thing}):
         assert inject(f)() is thing
     with register(providers={Thing: lambda: thing}):
         assert inject(f)() is thing

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from typing import Optional, Union
 from unittest.mock import Mock
 
 import pytest
@@ -17,8 +16,8 @@ MOCK = Mock()
         (int, lambda x: MOCK(), int),  # processor can be a function
         # we can ask for a subclass of a provided types
         (Sequence, lambda x: MOCK(), list),
-        (Union[list, tuple], lambda x: MOCK(), tuple),
-        (Union[list, tuple], lambda x: MOCK(), list),
+        (list | tuple, lambda x: MOCK(), tuple),
+        (list | tuple, lambda x: MOCK(), list),
     ],
 )
 def test_set_processors(type, process, ask_type):
@@ -75,11 +74,11 @@ def test_processor_decorator(test_store: ino.Store) -> None:
 
 def test_optional_processors(test_store: ino.Store) -> None:
     """Test processing Optional[type]."""
-    assert not list(test_store.iter_processors(Optional[int]))
+    assert not list(test_store.iter_processors(int | None))
     assert not list(test_store.iter_processors(str))
 
     @test_store.mark_processor
-    def processes_int(x: int) -> Optional[int]:
+    def processes_int(x: int) -> int | None:
         return 1
 
     @test_store.mark_processor  # these decorators are equivalent
@@ -88,22 +87,22 @@ def test_optional_processors(test_store: ino.Store) -> None:
     # we don't have a processor guaranteed to take an int
     # assert not get_processor(int)
     # just an optional one
-    assert next(test_store.iter_processors(Optional[int])) is processes_int
+    assert next(test_store.iter_processors(int | None)) is processes_int
 
     # but processes_string takes a string
     assert next(test_store.iter_processors(str)) is processes_string
     # which means it also provides an Optional[str]
-    assert next(test_store.iter_processors(Optional[str])) is processes_string
+    assert next(test_store.iter_processors(str | None)) is processes_string
 
     assert next(test_store.iter_processors(int)) is processes_int
     # the definite processor takes precedence
     # TODO: consider this...
-    assert next(test_store.iter_processors(Optional[int])) is processes_int
+    assert next(test_store.iter_processors(int | None)) is processes_int
 
 
 def test_union_processors(test_store: ino.Store) -> None:
     @test_store.mark_processor
-    def processes_int_or_str(x: Union[int, str]) -> int:
+    def processes_int_or_str(x: int | str) -> int:
         return 1
 
     assert next(test_store.iter_processors(int)) is processes_int_or_str

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from typing import Optional
 
 import pytest
 
@@ -9,12 +8,12 @@ import in_n_out as ino
 def test_provider_resolution():
     with ino.register(
         providers=[
-            (lambda: None, Optional[int]),
-            (lambda: 2, Optional[int]),
+            (lambda: None, int | None),
+            (lambda: 2, int | None),
             (lambda: 1, int),
         ]
     ):
-        assert ino.Store.get_store().provide(Optional[int]) == 2
+        assert ino.Store.get_store().provide(int | None) == 2
 
 
 @pytest.mark.parametrize(
@@ -50,11 +49,11 @@ def test_provider_decorator(test_store: ino.Store) -> None:
 
 def test_optional_providers(test_store: ino.Store) -> None:
     """Test providing & getting Optional[type]."""
-    assert not list(test_store.iter_providers(Optional[int]))
+    assert not list(test_store.iter_providers(int | None))
     assert not list(test_store.iter_providers(str))
 
     @test_store.mark_provider
-    def provides_optional_int() -> Optional[int]:
+    def provides_optional_int() -> int | None:
         return 1
 
     @test_store.mark_provider
@@ -63,12 +62,12 @@ def test_optional_providers(test_store: ino.Store) -> None:
 
     assert test_store.provide(int) == 1
     # just an optional one
-    assert next(test_store.iter_providers(Optional[int])) is provides_optional_int
+    assert next(test_store.iter_providers(int | None)) is provides_optional_int
 
     # but provides_str returns a string
     assert next(test_store.iter_providers(str)) is provides_str
-    # which means it also provides an Optional[str]
-    assert next(test_store.iter_providers(Optional[str])) is provides_str
+    # which means it also provides an str | None
+    assert next(test_store.iter_providers(str | None)) is provides_str
 
     # also register a provider for int
     @test_store.mark_provider(weight=10)
@@ -78,7 +77,7 @@ def test_optional_providers(test_store: ino.Store) -> None:
     assert next(test_store.iter_providers(int)) is provides_int
     # the definite provider takes precedence
     # TODO: consider this...
-    assert next(test_store.iter_providers(Optional[int])) is provides_int
+    assert next(test_store.iter_providers(int | None)) is provides_int
 
     test_store.clear()
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from unittest.mock import Mock
 
 import pytest
@@ -43,7 +42,7 @@ def test_store_clear(test_store: Store) -> None:
     assert not test_store._processors
 
     test_store.register(providers={int: 1})
-    test_store.register(providers={Optional[str]: None})
+    test_store.register(providers={str | None: None})
     test_store.register(processors={int: print})
     assert len(test_store._providers) == 2
     assert len(test_store._processors) == 1

--- a/tests/test_type_resolution.py
+++ b/tests/test_type_resolution.py
@@ -1,5 +1,6 @@
 import types
-from typing import Any, Callable, Optional, Union
+import typing
+from typing import Any
 
 import pytest
 
@@ -11,7 +12,7 @@ from in_n_out import (
 from in_n_out._type_resolution import _resolve_sig_or_inform
 
 
-def basic_sig(a: int, b: str, c: Union[float, None] = None) -> int: ...  # type: ignore
+def basic_sig(a: int, b: str, c: float | None = None) -> int: ...  # type: ignore
 def requires_unknown(param: "Unknown", x) -> "Unknown": ...  # type: ignore # noqa
 def optional_unknown(param: "Unknown" = 1) -> "Unknown": ...  # type: ignore # noqa
 
@@ -21,7 +22,7 @@ def test_resolve_type_hints():
         resolve_type_hints(requires_unknown)
 
     hints = resolve_type_hints(basic_sig)
-    assert hints["c"] == Optional[float]
+    assert hints["c"] == float | None
 
     hints = resolve_type_hints(requires_unknown, localns={"Unknown": int})
     assert hints["param"] is int
@@ -37,15 +38,15 @@ def test_resolve_single_type_hints():
 
     assert hints == (
         int,
-        Optional[int],
+        int | None,
         types.FunctionType,
-        Callable[..., Any],
+        typing.Callable[..., Any],
     )
 
 
 def test_type_resolved_signature():
     sig = type_resolved_signature(basic_sig)
-    assert sig.parameters["c"].annotation == Optional[float]
+    assert sig.parameters["c"].annotation == float | None
 
     with pytest.raises(NameError, match="use `raise_unresolved_optional_args=False`"):
         type_resolved_signature(optional_unknown)

--- a/tests/test_type_support.py
+++ b/tests/test_type_support.py
@@ -1,9 +1,8 @@
 from collections import ChainMap
-from collections.abc import Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Generic,
     NewType,
     TypeVar,

--- a/tests/typesafety/test_types.py
+++ b/tests/typesafety/test_types.py
@@ -34,7 +34,7 @@ def mypy_test_injection() -> None:
     injected()  # no error
     injected(1)
 
-    # unfortunately, the best we can do is convert the signature to Callabe[..., R]
+    # unfortunately, the best we can do is convert the signature to Callable[..., R]
     # so we lose the parameter information.  but it seems better than having
     # "missing positional args" errors everywhere on injected functions.
     injected(1, 2)


### PR DESCRIPTION
I'm currently starting to use `app-model` and `in-n-out` for my own project, and there are a couple of features I wanted to introduce.

Before doing that, I wanted to update the current state of the repository to drop Python 3.9 (which has been in EOL status for almost an year now) and support 3.14

It's mostly chores:

- update versions of pre-commit hooks to the most recent versions
- remove usage of `typing.Optional` and `typing.Union` in favor of pipe operator `|` for both
- use `collections.abc.Callable` instead of `typing.Callable` (this is the effect of the latest `0.16` release of ruff)
- ruff also automatically changes `'` characters to `"` in the documentation for code snippets. Quite nifty I must say!

Also fixes a small typo I found in a comment.

Since Python 3.10 goes EOL beginning of October, I was tempted to bump the minimum version to 3.11 now, but honestly it's not that critical so maybe another release might be warranted in the future.

I hope it's not too much!

EDIT: I received some help from Claude in updating the CI and pre-commit, most of the chore changes I did by hand though.